### PR TITLE
chore: update github action to publish package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,27 +1,14 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
 
-name: Node.js Package
+name: Publish Package
 
 on:
-    push:
-        branches:
-            - 'release/**'
     release:
-        types: [created]
+        types: [published]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v2
-              with:
-                  node-version: 12
-            - run: npm i
-
     publish-npm:
-        needs: build
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
updated github action so that whenever we create a new release then only it will be triggered and publish the package to npm